### PR TITLE
Add waiting logic and configurable player count

### DIFF
--- a/servidor.py
+++ b/servidor.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 from flask_socketio import SocketIO, emit
 import random
 import string
@@ -8,25 +8,40 @@ socketio = SocketIO(app, async_mode='threading')
 
 jugadores = {}
 letra_actual = ''
+expected_players = None
 
 def nueva_letra():
     return random.choice(string.ascii_uppercase)
 
+def comenzar_ronda():
+    global letra_actual
+    letra_actual = nueva_letra()
+    socketio.emit('letra', letra_actual, broadcast=True)
+
 @app.route('/')
 def index():
-    return render_template('index.html')
+    global expected_players
+    count = request.args.get('count', type=int)
+    if count:
+        expected_players = count
+    return render_template('index.html', expected_players=expected_players)
 
 @socketio.on('unirse')
 def unirse(data):
     nombre = data['nombre']
     jugadores[nombre] = {'puntos': 0}
     emit('jugadores_actualizados', jugadores, broadcast=True)
+    if expected_players:
+        if len(jugadores) < expected_players:
+            socketio.emit('esperando',
+                           {'actual': len(jugadores), 'esperados': expected_players},
+                           broadcast=True)
+        elif len(jugadores) == expected_players:
+            comenzar_ronda()
 
 @socketio.on('nueva_ronda')
 def iniciar_ronda():
-    global letra_actual
-    letra_actual = nueva_letra()
-    emit('letra', letra_actual, broadcast=True)
+    comenzar_ronda()
 
 @socketio.on('enviar_respuestas')
 def recibir_respuestas(data):

--- a/static/script.js
+++ b/static/script.js
@@ -9,7 +9,7 @@ function registrarse() {
     }
     socket.emit("unirse", { nombre: miNombre });
     document.getElementById("registro").style.display = "none";
-    document.getElementById("juego").style.display = "block";
+    document.getElementById("espera").style.display = "block";
 }
 
 function nuevaRonda() {
@@ -18,6 +18,8 @@ function nuevaRonda() {
 
 socket.on("letra", function(letra) {
     document.getElementById("letra").innerText = letra;
+    document.getElementById("espera").style.display = "none";
+    document.getElementById("juego").style.display = "block";
 });
 
 document.getElementById("formulario").addEventListener("submit", function(e) {
@@ -43,4 +45,10 @@ socket.on("jugadores_actualizados", function(jugadores) {
     for (var jugador in jugadores) {
         lista.innerHTML += "<li>" + jugador + ": " + jugadores[jugador].puntos + " pts</li>";
     }
+});
+
+socket.on("esperando", function(data) {
+    document.getElementById("cuenta").innerText = data.actual + "/" + data.esperados;
+    document.getElementById("espera").style.display = "block";
+    document.getElementById("juego").style.display = "none";
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,11 +5,18 @@
     <title>Juego STOP</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.min.js"></script>
     <script src="/static/script.js"></script>
+    <script>
+        var expectedPlayers = {{ expected_players if expected_players is not none else 'null' }};
+    </script>
 </head>
 <body>
     <h1>Juego STOP</h1>
     <div id="registro">
         <p>Ingresa tu nombre: <input id="nombre" /><button onclick="registrarse()">Unirse</button></p>
+    </div>
+
+    <div id="espera" style="display:none;">
+        <p>Esperando jugadores... (<span id="cuenta"></span>)</p>
     </div>
 
     <div id="juego" style="display:none;">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,3 +9,9 @@ def test_index_route():
     with app.test_client() as client:
         response = client.get('/')
         assert response.status_code == 200
+
+
+def test_index_route_with_count():
+    with app.test_client() as client:
+        response = client.get('/?count=2')
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add `expected_players` configurable via `/?count=N`
- auto-start round when all players joined and broadcast waiting state
- update UI to display waiting message until start
- update client script for waiting logic
- test index route with count

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4bd4ef0c83238525614dc9f68c16