### PR TITLE
Implement scoring logic for STOP game

### DIFF
--- a/servidor.py
+++ b/servidor.py
@@ -9,6 +9,39 @@ socketio = SocketIO(app, async_mode='threading')
 jugadores = {}
 letra_actual = ''
 
+
+def calcular_puntos_ronda(jugadores):
+    """Return a dict of round scores for each player based on their
+    stored answers in ``jugadores``.
+
+    Answers that are empty or don't start with the current letter are
+    ignored. If an answer is unique for its category it is worth 100
+    points, otherwise 50.
+    """
+    # Gather counts of each answer per category
+    categoria_conteos = {}
+    for datos in jugadores.values():
+        for categoria, respuesta in datos.get("respuestas", {}).items():
+            if respuesta:
+                categoria_conteos.setdefault(categoria, {})
+                key = respuesta.strip().lower()
+                categoria_conteos[categoria][key] = categoria_conteos[categoria].get(key, 0) + 1
+
+    # Compute score for each player
+    puntajes = {}
+    for nombre, datos in jugadores.items():
+        puntaje = 0
+        for categoria, respuesta in datos.get("respuestas", {}).items():
+            if not respuesta:
+                continue
+            key = respuesta.strip().lower()
+            if categoria_conteos.get(categoria, {}).get(key, 0) == 1:
+                puntaje += 100
+            else:
+                puntaje += 50
+        puntajes[nombre] = puntaje
+    return puntajes
+
 def nueva_letra():
     return random.choice(string.ascii_uppercase)
 
@@ -19,21 +52,41 @@ def index():
 @socketio.on('unirse')
 def unirse(data):
     nombre = data['nombre']
-    jugadores[nombre] = {'puntos': 0}
+    jugadores[nombre] = {'puntos': 0, 'respuestas': {}, 'puntos_ronda': 0}
     emit('jugadores_actualizados', jugadores, broadcast=True)
 
 @socketio.on('nueva_ronda')
 def iniciar_ronda():
     global letra_actual
     letra_actual = nueva_letra()
+    for datos in jugadores.values():
+        datos['respuestas'] = {}
+        datos['puntos_ronda'] = 0
     emit('letra', letra_actual, broadcast=True)
 
 @socketio.on('enviar_respuestas')
 def recibir_respuestas(data):
     nombre = data['nombre']
     respuestas = data['respuestas']
-    puntos = sum(10 for r in respuestas.values() if r.strip() != '')
-    jugadores[nombre]['puntos'] += puntos
+
+    # Guardar solo respuestas que comiencen con la letra actual
+    procesadas = {}
+    for categoria, respuesta in respuestas.items():
+        r = respuesta.strip()
+        if r.upper().startswith(letra_actual):
+            procesadas[categoria] = r
+        else:
+            procesadas[categoria] = ""
+
+    jugadores[nombre]['respuestas'] = procesadas
+
+    # Recalcular puntajes de la ronda y actualizar acumulados
+    nuevos_puntajes = calcular_puntos_ronda(jugadores)
+    for jugador, puntaje in nuevos_puntajes.items():
+        diff = puntaje - jugadores[jugador].get('puntos_ronda', 0)
+        jugadores[jugador]['puntos'] += diff
+        jugadores[jugador]['puntos_ronda'] = puntaje
+
     emit('jugadores_actualizados', jugadores, broadcast=True)
 
 if __name__ == '__main__':

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,24 @@
+import servidor
+
+
+def test_calcular_puntos_unique():
+    jugadores = {
+        'p1': {'respuestas': {'nombre': 'Ana'}},
+        'p2': {'respuestas': {'nombre': 'Bea'}},
+    }
+    puntajes = servidor.calcular_puntos_ronda(jugadores)
+    assert puntajes['p1'] == 100
+    assert puntajes['p2'] == 100
+
+
+def test_calcular_puntos_duplicate():
+    jugadores = {
+        'p1': {'respuestas': {'nombre': 'Ana'}},
+        'p2': {'respuestas': {'nombre': 'Ana'}},
+        'p3': {'respuestas': {'nombre': ''}},
+    }
+    puntajes = servidor.calcular_puntos_ronda(jugadores)
+    assert puntajes['p1'] == 50
+    assert puntajes['p2'] == 50
+    assert puntajes['p3'] == 0
+


### PR DESCRIPTION
## Summary
- add `calcular_puntos_ronda` to evaluate answers
- store round answers for each player and recompute points
- award 100 points for unique answers or 50 otherwise
- broadcast updated scores after each submission
- test scoring behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4bc158708323a251afaca7450259