### PR TITLE
Fix bug in join event and add multiplayer test

### DIFF
--- a/servidor.py
+++ b/servidor.py
@@ -52,7 +52,7 @@ def index():
 @socketio.on('unirse')
 def unirse(data):
     nombre = data['nombre']
-    jujugadores[nombre] = {'puntos': 0, 'respuestas': {}, 'puntos_ronda': 0}
+    jugadores[nombre] = {'puntos': 0, 'respuestas': {}, 'puntos_ronda': 0}
     emit('jugadores_actualizados', jugadores, broadcast=True)
 
 @socketio.on('nueva_ronda')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,17 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from servidor import app
+from servidor import app, socketio, jugadores
+
+
+def test_unirse_event():
+    jugadores.clear()
+    client = socketio.test_client(app)
+    client.emit('unirse', {'nombre': 'Jugador1'})
+    client.emit('unirse', {'nombre': 'Jugador2'})
+    assert 'Jugador1' in jugadores
+    assert 'Jugador2' in jugadores
+    client.disconnect()
 
 
 def test_index_route():


### PR DESCRIPTION
## Summary
- fix typo in `servidor.unirse` that prevented players from joining
- add test ensuring multiple players can join

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ccd9913d083238ba781e6b11548b0